### PR TITLE
Added Warning in CMakeLists.txt to verify GLFW presence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ project(GLFWPP CXX)
 #Options
 option(GLFWPP_BUILD_EXAMPLES "Should examples be built" ON)
 
+if(NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/external/glfw/include")
+    message(FATAL_ERROR "GLFW dependency not found in ./external/glfw... !!"
+        "\nYou may not have cloned the submodules recursively with --recursive "
+        "\n\`git submodule update --init --recursive\` will get the required dependencies"
+    )
+endif()
+
 #Add GFLW
 set(GLFW_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Added a few lines to CMakeLists.txt to verify whether the external dependencies were cloned alongside the repo too.

Earlier:
![image](https://user-images.githubusercontent.com/37269665/106497122-abf13e80-64e3-11eb-8597-4779d82f0aee.png)

After the commit:
![image](https://user-images.githubusercontent.com/37269665/106497203-c3c8c280-64e3-11eb-9e98-c7c18db3e169.png)

Actually, i faced this problem myself, initially thinking i have to link the GLFW dependency too, these few lines may help, some beginners like me not think they have to clone GLFW elsewhere 😄