### PR TITLE
Headers should't generate code.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,3 @@
 [submodule "external/imgui/imgui"]
 	path = external/imgui/imgui
 	url = https://github.com/ocornut/imgui.git
-	branch = docking

--- a/include/glfwpp/event.h
+++ b/include/glfwpp/event.h
@@ -27,21 +27,47 @@ namespace glfw
         }
     };
 
-    void pollEvents()
+    template<typename... Args>
+    class StaticEvent
+    {
+    private:
+        static std::function<void(Args...)> _handler;
+
+    public:
+        template<typename CallbackT>
+        static void setCallback(CallbackT&& callback_)
+        {
+            _handler = std::forward<CallbackT>(callback_);
+        }
+        static void call(Args... args_)
+        {
+            if(_handler)
+            {
+                _handler(args_...);
+            }
+        }
+    };
+
+    // static
+    template<typename... Args>
+    std::function<void(Args...)> StaticEvent<Args...>::_handler;
+
+    [[gnu::always_inline]] inline void pollEvents()
     {
         glfwPollEvents();
     }
 
-    void waitEvents()
+    [[gnu::always_inline]] inline void waitEvents()
     {
         glfwWaitEvents();
     }
-    void waitEvents(double timeout_)
+
+    [[gnu::always_inline]] inline void waitEvents(double timeout_)
     {
         glfwWaitEventsTimeout(timeout_);
     }
 
-    void postEmptyEvent()
+    [[gnu::always_inline]] inline void postEmptyEvent()
     {
         glfwPostEmptyEvent();
     }

--- a/include/glfwpp/glfwpp.h
+++ b/include/glfwpp/glfwpp.h
@@ -15,7 +15,7 @@ namespace glfw
 {
     namespace impl
     {
-        void errorCallback(int errorCode_, const char* what_)
+        inline void errorCallback(int errorCode_, const char* what_)
         {
             // Error handling philosophy as per http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0709r4.pdf (section 1.1)
 
@@ -51,14 +51,14 @@ namespace glfw
             }
         }
 
-        void monitorCallback(GLFWmonitor* monitor_, int eventType_)
+        [[gnu::always_inline]] inline void monitorCallback(GLFWmonitor* monitor_, int eventType_)
         {
-            monitorEvent(Monitor{monitor_}, MonitorEventType{eventType_});
+            monitorEvent::call(Monitor{monitor_}, MonitorEventType{eventType_});
         }
 
-        void joystickCallback(int jid_, int eventType_)
+        [[gnu::always_inline]] inline void joystickCallback(int jid_, int eventType_)
         {
-            joystickEvent(Joystick{static_cast<decltype(Joystick::Joystick1)>(jid_)}, static_cast<JoystickEvent>(eventType_));
+            joystickEvent::call(Joystick{static_cast<decltype(Joystick::Joystick1)>(jid_)}, static_cast<JoystickEvent>(eventType_));
         }
     }  // namespace impl
 
@@ -104,50 +104,50 @@ namespace glfw
 
     [[nodiscard]] GlfwLibrary init();
 
-    [[nodiscard]] Version getVersion()
+    [[nodiscard, gnu::always_inline]] inline Version getVersion()
     {
         Version version{};
         glfwGetVersion(&version.major, &version.minor, &version.revision);
         return version;
     }
 
-    [[nodiscard]] const char* getVersionString()
+    [[nodiscard, gnu::always_inline]] inline const char* getVersionString()
     {
         return glfwGetVersionString();
     }
 
-    [[nodiscard]] bool rawMouseMotionSupported()
+    [[nodiscard, gnu::always_inline]] inline bool rawMouseMotionSupported()
     {
         return glfwRawMouseMotionSupported();
     }
 
-    void setClipboardString(const char* content_)
+    [[gnu::always_inline]] inline void setClipboardString(const char* content_)
     {
         glfwSetClipboardString(nullptr, content_);
     }
 
-    [[nodiscard]] const char* getClipboardString()
+    [[nodiscard, gnu::always_inline]] inline const char* getClipboardString()
     {
         return glfwGetClipboardString(nullptr);
     }
 
-    [[nodiscard]] bool extensionSupported(const char* extensionName_)
+    [[nodiscard, gnu::always_inline]] inline bool extensionSupported(const char* extensionName_)
     {
         return glfwExtensionSupported(extensionName_);
     }
 
     using GlProc = GLFWglproc;
-    [[nodiscard]] GlProc getProcAddress(const char* procName_)
+    [[nodiscard, gnu::always_inline]] inline GlProc getProcAddress(const char* procName_)
     {
         return glfwGetProcAddress(procName_);
     }
 
-    [[nodiscard]] bool vulkanSupported()
+    [[nodiscard, gnu::always_inline]] inline bool vulkanSupported()
     {
         return glfwVulkanSupported();
     }
 
-    [[nodiscard]] std::vector<const char*> getRequiredInstanceExtensions()
+    [[nodiscard, gnu::always_inline]] inline std::vector<const char*> getRequiredInstanceExtensions()
     {
         unsigned count;
         auto pExtensionNames = glfwGetRequiredInstanceExtensions(&count);
@@ -162,12 +162,12 @@ namespace glfw
     }
     using VkProc = GLFWvkproc;
 #if defined(VK_VERSION_1_0)
-    [[nodiscard]] VkProc getInstanceProcAddress(VkInstance instance, const char* procName)
+    [[nodiscard, gnu::always_inline]] inline VkProc getInstanceProcAddress(VkInstance instance, const char* procName)
     {
         return glfwGetInstanceProcAddress(instance, procName);
     }
 
-    [[nodiscard]] bool getPhysicalDevicePresentationSupport(
+    [[nodiscard, gnu::always_inline]] inline bool getPhysicalDevicePresentationSupport(
             VkInstance instance,
             VkPhysicalDevice device,
             uint32_t queueFamily)
@@ -177,11 +177,11 @@ namespace glfw
 #endif  // VK_VERSION_1_0
 
 #ifdef VULKAN_HPP
-    [[nodiscard]] VkProc getInstanceProcAddress(const vk::Instance& instance, const char* procName)
+    [[nodiscard, gnu::always_inline]] inline VkProc getInstanceProcAddress(const vk::Instance& instance, const char* procName)
     {
         return getInstanceProcAddress(static_cast<VkInstance>(instance), procName);
     }
-    [[nodiscard]] bool getPhysicalDevicePresentationSupport(
+    [[nodiscard, gnu::always_inline]] inline bool getPhysicalDevicePresentationSupport(
             const vk::Instance& instance,
             const vk::PhysicalDevice& device,
             uint32_t queueFamily)
@@ -190,22 +190,22 @@ namespace glfw
     }
 #endif  // VULKAN_HPP
 
-    [[nodiscard]] double getTime()
+    [[nodiscard, gnu::always_inline]] inline double getTime()
     {
         return glfwGetTime();
     }
 
-    void setTime(double time_)
+    [[gnu::always_inline]] inline void setTime(double time_)
     {
         glfwSetTime(time_);
     }
 
-    [[nodiscard]] uint64_t getTimerValue()
+    [[nodiscard, gnu::always_inline]] inline uint64_t getTimerValue()
     {
         return glfwGetTimerValue();
     }
 
-    [[nodiscard]] uint64_t getTimerFrequency()
+    [[nodiscard, gnu::always_inline]] inline uint64_t getTimerFrequency()
     {
         return glfwGetTimerFrequency();
     }

--- a/include/glfwpp/helper.h
+++ b/include/glfwpp/helper.h
@@ -4,19 +4,19 @@
 #include <type_traits>
 
 #define GLFWPP_ENUM_FLAGS_OPERATORS(Enum)                                                                       \
-    std::underlying_type_t<Enum> operator~(Enum lhs)                                                            \
+    [[gnu::always_inline]] inline std::underlying_type_t<Enum> operator~(Enum lhs)                              \
     {                                                                                                           \
         return ~static_cast<std::underlying_type_t<Enum>>(lhs);                                                 \
     }                                                                                                           \
-    std::underlying_type_t<Enum> operator&(Enum lhs, Enum rhs)                                                  \
+    [[gnu::always_inline]] inline std::underlying_type_t<Enum> operator&(Enum lhs, Enum rhs)                    \
     {                                                                                                           \
         return static_cast<std::underlying_type_t<Enum>>(lhs) & static_cast<std::underlying_type_t<Enum>>(rhs); \
     }                                                                                                           \
-    std::underlying_type_t<Enum> operator|(Enum lhs, Enum rhs)                                                  \
+    [[gnu::always_inline]] inline std::underlying_type_t<Enum> operator|(Enum lhs, Enum rhs)                    \
     {                                                                                                           \
         return static_cast<std::underlying_type_t<Enum>>(lhs) | static_cast<std::underlying_type_t<Enum>>(rhs); \
     }                                                                                                           \
-    std::underlying_type_t<Enum> operator^(Enum lhs, Enum rhs)                                                  \
+    [[gnu::always_inline]] inline std::underlying_type_t<Enum> operator^(Enum lhs, Enum rhs)                    \
     {                                                                                                           \
         return static_cast<std::underlying_type_t<Enum>>(lhs) ^ static_cast<std::underlying_type_t<Enum>>(rhs); \
     }

--- a/include/glfwpp/joystick.h
+++ b/include/glfwpp/joystick.h
@@ -199,9 +199,9 @@ namespace glfw
         }
     };
 
-    Event<Joystick, JoystickEvent> joystickEvent;
+    using joystickEvent = StaticEvent<Joystick, JoystickEvent>;
 
-    [[nodiscard]] bool updateGamepadMappings(const char* string_)
+    [[nodiscard, gnu::always_inline]] inline bool updateGamepadMappings(const char* string_)
     {
         return glfwUpdateGamepadMappings(string_);
     }

--- a/include/glfwpp/monitor.h
+++ b/include/glfwpp/monitor.h
@@ -133,7 +133,7 @@ namespace glfw
         Connected = GLFW_CONNECTED,
         Disconnected = GLFW_DISCONNECTED
     };
-    Event<Monitor, MonitorEventType> monitorEvent;
+    using monitorEvent = StaticEvent<Monitor, MonitorEventType>;
 }  // namespace glfw
 
 #endif  //GLFWPP_MONITOR_H

--- a/include/glfwpp/window.h
+++ b/include/glfwpp/window.h
@@ -370,7 +370,7 @@ namespace glfw
         }
     };
     [[nodiscard]] const char* getKeyName(KeyCode::EnumType);
-    [[nodiscard]] const char* getKeyName(int scanCode_)
+    [[nodiscard, gnu::always_inline]] inline const char* getKeyName(int scanCode_)
     {
         return glfwGetKeyName(KeyCode::Unknown, scanCode_);
     }
@@ -950,7 +950,7 @@ namespace glfw
     void makeContextCurrent(const Window& window_);
     [[nodiscard]] Window& getCurrentContext();
 
-    void swapInterval(int interval_)
+    [[gnu::always_inline]] inline void swapInterval(int interval_)
     {
         glfwSwapInterval(interval_);
     }

--- a/include/glfwpp/window.h
+++ b/include/glfwpp/window.h
@@ -4,6 +4,9 @@
 #include "event.h"
 #include "monitor.h"
 #include "helper.h"     // Needed for GLFWPP_ENUM_FLAGS_OPERATORS.
+#ifdef VULKAN_HPP
+#include "error.h"
+#endif
 
 namespace glfw
 {
@@ -935,14 +938,22 @@ namespace glfw
 #ifdef VULKAN_HPP
         [[nodiscard]] vk::SurfaceKHR createSurface(
                 const vk::Instance& instance,
-                const vk::AllocationCallbacks* allocator)
+                const vk::AllocationCallbacks& allocator)
         {
             VkSurfaceKHR surface;
-            VkResult result = createSurface(instance, allocator, &surface);
+            VkAllocationCallbacks allocator_tmp = allocator;
+            VkResult result = createSurface(instance, &allocator_tmp, &surface);
             if(result < 0)
-            {
                 throw Error("Could not create window surface");
-            }
+            return surface;
+        }
+        [[nodiscard]] vk::SurfaceKHR createSurface(
+                const vk::Instance& instance)
+        {
+            VkSurfaceKHR surface;
+            VkResult result = createSurface(instance, nullptr, &surface);
+            if(result < 0)
+                throw Error("Could not create window surface");
             return surface;
         }
 #endif  // VULKAN_HPP


### PR DESCRIPTION
This is needed to avoid "Multiple instantiations of ..." linker errors (a lot of them).

Not sure why you want this library to be header only?

You can ignore the first commit (couldn't get rid of it in the pull request), or use it if
it doesn't break anything for you (as far as I know 'branch' is normally not used?)