### PR TITLE
Fix native.h and getting GLFW dependencies in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,9 @@ jobs:
 
     - name: Install GLFW dependencies
       if: ${{matrix.os == 'ubuntu-latest'}}
-      run: sudo apt-get -m install libxrandr-dev libxinerama-dev libx11-dev libxcursor-dev libxi-dev libxext-dev libegl1-mesa-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get -m install libxrandr-dev libxinerama-dev libx11-dev libxcursor-dev libxi-dev libxext-dev libegl1-mesa-dev
 
     - name: Create Build Environment
       run: mkdir ${{runner.workspace}}/build

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vs
 out
 cmake-build*
+build
 *.DotSettings.user

--- a/README.md
+++ b/README.md
@@ -117,16 +117,22 @@ Here is a quick comparison of GLFW and GLFWPP. The following code creates a Open
 The functionality is split between files, as follows:
 
 -   `error.h` - things related to error handling (exception types etc.). All GLFW errors are detected by the library and thrown as exceptions. The exception type matches [the respective GLFW error code](https://www.glfw.org/docs/latest/group__errors.html).
+
 -   `glfwpp.h` - main header with, includes all other headers. Contains:
     -   [The `init` function](https://www.glfw.org/docs/latest/intro_guide.html#intro_init_init). [Initialization hints](https://www.glfw.org/docs/latest/intro_guide.html#init_hints) are passed with `glfw::InitHints`. The RAII wrapper `glfw::GlfwLibrary` takes care of calling [`glfwTerminate()`](https://www.glfw.org/docs/latest/intro_guide.html#intro_init_terminate).
     -   [Version management](https://www.glfw.org/docs/latest/intro_guide.html#intro_version).
     -   [Time input](https://www.glfw.org/docs/latest/input_guide.html#time).
     -   [Clipboard input and output](https://www.glfw.org/docs/latest/input_guide.html#clipboard).
     -   [Vulkan specific functionality](https://www.glfw.org/docs/latest/vulkan_guide.html). Compatible with both `vulkan.h` and [Vulkan-Hpp](https://github.com/KhronosGroup/Vulkan-Hpp).
+
 -   `event.h` - `glfw::Event` class used for specifying all user callbacks as well as event management functions.
+
 -   `joystick.h` - `glfw::Joystick` class and [functionality related to joystick input](https://www.glfw.org/docs/latest/input_guide.html#joystick)
+
 -   `monitor.h` - `glfw::Monitor` and other functionality related to [monitor management](https://www.glfw.org/docs/latest/monitor_guide.html).
+
 -   `window.h` - `glfw::Window` class, `glfw::Cursor` class, `glfw::KeyCode` class and other functionality related to managing [windows](https://www.glfw.org/docs/latest/window_guide.html), [window contexts](https://www.glfw.org/docs/latest/context_guide.html) and [window input](https://www.glfw.org/docs/latest/input_guide.html) (clipboard and time IO in `glfwpp.h`). [Window hints](https://www.glfw.org/docs/latest/window_guide.html#window_hints) are specified using `glfw::WindowHints`.
+
 -   `native.h` - functions for [native access](https://www.glfw.org/docs/latest/group__native.html) wrapping around `glfw3native.h`.
 
 ## Interoperability

--- a/include/glfwpp/native.h
+++ b/include/glfwpp/native.h
@@ -1,47 +1,51 @@
 #ifndef GLFWPP_NATIVE_H
 #define GLFWPP_NATIVE_H
 
+#include <GLFW/glfw3.h>
 #include <GLFW/glfw3native.h>
+
+#include "monitor.h"
+#include "window.h"
 
 namespace glfw
 {
     namespace native
     {
 #if defined(GLFW_EXPOSE_NATIVE_WIN32)
-        [[nodiscard]] inline const char* getWin32Adapter(const Monitor& monitor_)
+        [[nodiscard]] inline const char* getWin32Adapter(const glfw::Monitor& monitor_)
         {
             return glfwGetWin32Adapter(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline const char* getWin32Monitor(const Monitor& monitor_)
+        [[nodiscard]] inline const char* getWin32Monitor(const glfw::Monitor& monitor_)
         {
             return glfwGetWin32Monitor(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline ::HWND getWin32Window(Window& window_)
+        [[nodiscard]] inline ::HWND getWin32Window(glfw::Window& window_)
         {
             return glfwGetWin32Window(static_cast<GLFWwindow*>(window_));
         }
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_WGL)
-        [[nodiscard]] inline ::HGLRC getWGLContext(Window& window_)
+        [[nodiscard]] inline ::HGLRC getWGLContext(glfw::Window& window_)
         {
             return glfwGetWGLContext(static_cast<GLFWwindow*>(window_));
         }
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_COCOA)
-        [[nodiscard]] inline ::CGDirectDisplayID getCocoaMonitor(const Monitor& monitor_)
+        [[nodiscard]] inline ::CGDirectDisplayID getCocoaMonitor(const glfw::Monitor& monitor_)
         {
             return glfwGetCocoaMonitor(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline ::id getCocoaWindow(Window& window_)
+        [[nodiscard]] inline ::id getCocoaWindow(glfw::Window& window_)
         {
             return glfwGetCocoaWindow(static_cast<GLFWwindow*>(window_));
         }
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_NSGL)
-        [[nodiscard]] inline ::id getNSGLContext(Window& window_)
+        [[nodiscard]] inline ::id getNSGLContext(glfw::Window& window_)
         {
             return glfwGetNSGLContext(static_cast<GLFWwindow*>(window_));
         }
@@ -52,15 +56,15 @@ namespace glfw
         {
             return glfwGetX11Display();
         }
-        [[nodiscard]] inline ::RRCrtc getX11Adapter(Monitor& monitor_)
+        [[nodiscard]] inline ::RRCrtc getX11Adapter(glfw::Monitor& monitor_)
         {
             return glfwGetX11Adapter(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline ::RROutput getX11Monitor(Monitor& monitor_)
+        [[nodiscard]] inline ::RROutput getX11Monitor(glfw::Monitor& monitor_)
         {
             return glfwGetX11Monitor(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline ::Window getX11Window(Window& window_)
+        [[nodiscard]] inline ::Window getX11Window(glfw::Window& window_)
         {
             return glfwGetX11Window(static_cast<GLFWwindow*>(window_));
         }
@@ -75,11 +79,11 @@ namespace glfw
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_GLX)
-        [[nodiscard]] inline ::GLXContext getGLXContext(Window& window_)
+        [[nodiscard]] inline ::GLXContext getGLXContext(glfw::Window& window_)
         {
             return glfwGetGLXContext(static_cast<GLFWwindow*>(window_));
         }
-        [[nodiscard]] inline ::GLXWindow getGLXWindow(Window& window_)
+        [[nodiscard]] inline ::GLXWindow getGLXWindow(glfw::Window& window_)
         {
             return glfwGetGLXWindow(static_cast<GLFWwindow*>(window_));
         }
@@ -90,11 +94,11 @@ namespace glfw
         {
             return glfwGetWaylandDisplay();
         }
-        [[nodiscard]] inline ::wl_output* getWaylandMonitor(Monitor& monitor_)
+        [[nodiscard]] inline ::wl_output* getWaylandMonitor(glfw::Monitor& monitor_)
         {
             return glfwGetWaylandMonitor(static_cast<GLFWmonitor*>(monitor_));
         }
-        [[nodiscard]] inline ::wl_surface* getWaylandWindow(Window& window_)
+        [[nodiscard]] inline ::wl_surface* getWaylandWindow(glfw::Window& window_)
         {
             return glfwGetWaylandWindow(static_cast<GLFWwindow*>(window_));
         }
@@ -105,32 +109,32 @@ namespace glfw
         {
             return glfwGetEGLDisplay();
         }
-        [[nodiscard]] inline ::EGLContext getEGLContext(Window& window_)
+        [[nodiscard]] inline ::EGLContext getEGLContext(glfw::Window& window_)
         {
             return glfwGetEGLContext(static_cast<GLFWwindow*>(window_));
         }
-        [[nodiscard]] inline ::EGLSurface getEGLSurface(Window& window_)
+        [[nodiscard]] inline ::EGLSurface getEGLSurface(glfw::Window& window_)
         {
             return glfwGetEGLSurface(static_cast<GLFWwindow*>(window_));
         }
 #endif
 
 #if defined(GLFW_EXPOSE_NATIVE_OSMESA)
-        [[nodiscard]] inline std::tuple<int, int, int, void*> getOSMesaColorBuffer(Window& window_)
+        [[nodiscard]] inline std::tuple<int, int, int, void*> getOSMesaColorBuffer(glfw::Window& window_)
         {
             int width, height, format;
             void* buffer;
             glfwGetOSMesaColorBuffer(static_cast<GLFWwindow*>(window_), &width, &height, &format, &buffer);
             return {width, height, format, buffer};
         }
-        [[nodiscard]] inline std::tuple<int, int, int, void*> getOSMesaDepthBuffer(Window& window_)
+        [[nodiscard]] inline std::tuple<int, int, int, void*> getOSMesaDepthBuffer(glfw::Window& window_)
         {
             int width, height, bytesPerValue;
             void* buffer;
             glfwGetOSMesaDepthBuffer(static_cast<GLFWwindow*>(window_), &width, &height, &bytesPerValue, &buffer);
             return {width, height, bytesPerValue, buffer};
         }
-        [[nodiscard]] inline ::OSMesaContext getOSMesaContext(Window& window_)
+        [[nodiscard]] inline ::OSMesaContext getOSMesaContext(glfw::Window& window_)
         {
             return glfwGetOSMesaContext(static_cast<GLFWwindow*>(window_));
         }


### PR DESCRIPTION
There were compile errors when using `native.h` related to missing include of GLFW headers and not using `glfw::` before class types. This should fix that and the CI, as for some time now it wasn't able to properly fetch GLFW dependencies on Ubuntu.