### PR TITLE
Fix crashes after Window move assignment

### DIFF
--- a/include/glfwpp/window.h
+++ b/include/glfwpp/window.h
@@ -670,7 +670,7 @@ namespace glfw
             _handle = std::exchange(other._handle, nullptr);
             _userPtr = std::exchange(other._userPtr, nullptr);
 
-            if(other._handle)
+            if(_handle)
             {
                 _setPointerFromHandle(_handle, this);
             }


### PR DESCRIPTION
Event handlers were hitting an access violation due to the user pointer pointing to the old invalid window.