### PR TITLE
Add missing `<utility>` include to `include/glfwpp/helper.h`

### DIFF
--- a/include/glfwpp/helper.h
+++ b/include/glfwpp/helper.h
@@ -2,6 +2,7 @@
 #define GLFWPP_HELPER_H
 
 #include <type_traits>
+#include <utility>
 
 #define GLFWPP_ENUM_FLAGS_OPERATORS(Enum)                                                                       \
     inline std::underlying_type_t<Enum> operator~(Enum lhs)                                                     \


### PR DESCRIPTION
Adds `#include <utility>` to `helper.h` for `std::exchange`.

Fixes #264 