### PR TITLE
Fix msvc warnings

### DIFF
--- a/include/glfwpp/glfwpp.h
+++ b/include/glfwpp/glfwpp.h
@@ -151,7 +151,7 @@ namespace glfw
 
         std::vector<const char*> extensionNames;
         extensionNames.reserve(count);
-        for(int i = 0; i < count; ++i)
+        for(unsigned i = 0; i < count; ++i)
         {
             extensionNames.push_back(pExtensionNames[i]);
         }

--- a/include/glfwpp/window.h
+++ b/include/glfwpp/window.h
@@ -689,7 +689,7 @@ namespace glfw
 
         void setIcon(const std::vector<Image>& iconCandidates_)
         {
-            glfwSetWindowIcon(_handle, iconCandidates_.size(), iconCandidates_.data());
+            glfwSetWindowIcon(_handle, static_cast<int>(iconCandidates_.size()), iconCandidates_.data());
         }
 
         [[nodiscard]] std::tuple<int, int> getPos() const


### PR DESCRIPTION
Fix this warnings in msvc:

glfwpp\include\glfwpp\window.h(692): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
glfwpp\include\glfwpp\glfwpp.h(154): warning C4018: '<': signed/unsigned mismatch